### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,8 @@ uploadArchives {
     }
 }
 
+tasks.withType(ScalaCompile) { scalaCompileOptions.useAnt = false }
+
 tasks.withType(ScalaDoc) {
     task srcJar(type:Jar) {
         classifier = 'sources'


### PR DESCRIPTION
By default with java8 installed this build fails with

```
Execution failed for task ':compileScala'. Unknown target 'jvm-1.8' 
```

This change fixes that issue by forcing it to compile using the [zinc compiler](https://github.com/typesafehub/zinc) instead of ant.